### PR TITLE
:bug: fix body css declared twice

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -173,7 +173,7 @@ footer {
     left: 0;
     margin-top: 20px; /* Add space between the footer and content */
 }
-canvas,body {
+canvas {
     max-width: 600px;
     margin: 0 auto;
     font-family: Arial, sans-serif;


### PR DESCRIPTION
This pull request includes a small change to the `css/style.css` file. The change modifies the `canvas,body` selector to apply the styles only to the `canvas` element.

* [`css/style.css`](diffhunk://#diff-1fc556f95754ee7e33d91044125c44bb9f750c99be4406756ffb27413adfcaf5L176-R176): Changed the selector from `canvas,body` to `canvas` to ensure that the styles are applied exclusively to the `canvas` element.